### PR TITLE
Documentation, prompting, and minor functional improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ the adapter always pre-configured. That way, you won't interfere with your norma
  Of course, if you usualy use Wi-Fi to connect to the Internet, and you don't use the Ethernet adapter that's built
 into your host computer, you might just want to dedicate that adapter to this purpose.  
 
+ If your host computer is connected to a corporate network, bear in mind that the network 192.168.2.*
+ might already be in use -- in that case, you won't be able to talk to the Conduit. TO be safe, 
+ disconnect your host computer from all other networks while doing the initial configuration.
+
+
 5. Copy `installer.sh` to the Conduit using Putty SCP (on Windows, `pscp.exe`) or `scp` (Cygwin, Linux or macOS).
 
   `host-machine $ `**`scp installer.sh root@192.168.2.1:`**
@@ -64,17 +69,19 @@ you're using ssh.
    Internet. However, do not connect the Conduit directly (without firewall) to
    the Internet to prevent possible security issues!
 
-   After the network settings have been provided, the Conduit shuts down. 
+   After the network settings have been provided, the Conduit shuts down so you can move it to the production network. 
 
- Note that the script says "the gateway wil now shutdown", but you need to press "enter" in order to 
- get the gateway to continue into the shutdown process.  Here's an example:
+ Here's an example:
 
- `The gateway will now shutdown. Remove power once the status led`   
- `stopped blinking, connect the gateway to the new network and reapply`  
- `power.`  
+ `When you press enter to confirm, the Conduit will start shutting down.`   
+ `Wait for the front-panel STATUS light to stop blinking. Then disconnect`  
+ `power from the Conduit, connect the Conduit to the new network, and`  
+ `reapply power.`
 
- `Press enter to continue`  
- _(press enter)_
+ `After the Conduit reboots, log in again as root (using the password you`
+ `set previously), and rerun installer.sh (this script) to complete the setup.`
+
+ `Press enter to begin shut-down process: `  _(press enter)_
 
  `Broadcast message from root@mtcdt (pts/0) (Sun Aug  7 17:08:03 2016):`  
   
@@ -84,12 +91,12 @@ you're using ssh.
  `-bash:myhost::/cygdrive/c/multitech-installer $ `
 
 7. Once the
-   LEDs on the front of the Conduit stop flashing, power the Conduit down and
+   lights on the front of the Conduit stop flashing, power the Conduit down and
    connect it to the target network. At the same time, **restore the network settings on your
    host computer** (if you changed them away from the default during step 4).
 
-8. Log on to the Conduit using putty/ssh with the IP address information provided in
-   step 6 or the IP address assigned to it by the DHCP server (when using DHCP)
+8. Log on to the Conduit as root, using putty or ssh. If using static addresses, you connect to the IP address provided in
+   step 6. If using DHCP, use the IP address assigned to it by the DHCP server.
 
 9. Restart the installer to continue installation.
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ the adapter always pre-configured. That way, you won't interfere with your norma
  Of course, if you usualy use Wi-Fi to connect to the Internet, and you don't use the Ethernet adapter that's built
 into your host computer, you might just want to dedicate that adapter to this purpose.  
 
- If your host computer is connected to a corporate network, bear in mind that the network 192.168.2.*
- might already be in use -- in that case, you won't be able to talk to the Conduit. TO be safe, 
+ If your host computer is connected to a corporate network, bear in mind that the network 192.168.2.0/24
+ might already be in use -- in that case, you won't be able to talk to the Conduit. To be safe, 
  disconnect your host computer from all other networks while doing the initial configuration.
 
 

--- a/installer.sh
+++ b/installer.sh
@@ -20,11 +20,22 @@ fi
 grep secure $STATUSFILE > /dev/null 2> /dev/null
 if [ $? -ne 0 ] ; then
 	# Start by securing the device
-	echo "Securing access to the device, enter the same password twice and"
-	echo "make sure to save this password as the device requires factory"
+	echo "We start by securing access to the Conduit, which initially is open."
+	echo "When prompted, enter the old password for root access (initially 'root')"
+	echo "and then enter a new password to be used to control root access."
+	echo "Please be sure to save this password, as the Conduit requires factory"
 	echo "reset when the password is lost!!"
+	echo ""
+	echo "(If you need to do a factory reset, it's easy, just hold the front-panel"
+	echo "reset button for 10 seconds and wait for the Conduit to reboot. However"
+	echo "all information on the Conduit root file system will be erased, and"
+	echo "you'll need to reconfigure from scratch.)"
 	passwd root
-	echo "secure" >> $STATUSFILE
+	if [ $? -eq 0 ] ; then
+		echo "secure" >> $STATUSFILE
+	else
+		echo "Password not set, exiting. Please restart the install process."
+	fi
 fi
 
 # now set the time zone
@@ -108,7 +119,7 @@ if [ $? -ne 0 ] ; then
 	# Interact with the user via stderr and stdin.
 	# Contributed by Paul Eggert.  This file is in the public domain.
 
-	# Specify default values for environment variables if they are unset.
+	# Specify default values for variables
 	AWK=awk
 	TZDIR=/usr/share/zoneinfo
 
@@ -522,21 +533,21 @@ _EOF_
 		No)
 			got_it=No
 			while [ $got_it != Yes ] ; do
-				echo "Please provide network parameters"
-				echo -n "IP address: "
+				echo "Please provide IPv4 network parameters."
+				echo -n "IPv4 address: "
 				read ip
 				echo -n "netmask: "
 				read mask
 				echo -n "gateway: "
 				read gw
-				echo -n "DNS IP (use 8.8.8.8 for Google DNS): "
+				echo -n "DNS server IPv4 address (use 8.8.8.8 for Google DNS): "
 				read dns
 				echo
 				echo "Supplied information:"
-				echo "IP     : $ip"
-				echo "Netmask: $mask"
-				echo "Gateway: $gw"
-				echo "DNS IP : $dns"		
+				echo "IPv4 address: $ip"
+				echo "  Netmask:    $mask"
+				echo "  Gateway:    $gw"
+				echo "  DNS IP :    $dns"
 				doselect Yes No
 				got_it=$select_result
 			done
@@ -577,11 +588,15 @@ _EOF_
 	echo "network" >> $STATUSFILE
 	echo "Network configuration written"
 	echo ""
-	echo "The gateway will now shutdown. Remove power once the status led"
-	echo "stopped blinking, connect the gateway to the new network and reapply"
-	echo "power."
+	echo "When you press enter to confirm, the Conduit will start shutting down."
+	echo "Wait for the front-panel STATUS light to stop blinking. Then disconnect"
+	echo "power from the Conduit, connect the Conduit to the new network, and"
+	echo "reapply power."
 	echo ""
-	echo "Press enter to continue"
+	echo "After the Conduit reboots, log in again as root (using the password you"
+	echo "set previously), and rerun $0 (this script) to complete the setup."
+	echo ""
+	echo -n "Press enter to begin shut-down process: "
 	read n
 	sync;sync;sync
 	shutdown -h now
@@ -592,8 +607,8 @@ fi
 #
 wget http://www.thethingsnetwork.org/ --no-check-certificate -O /dev/null -o /dev/null
 if [ $? -ne 0 ] ; then
-	echo "Error in network settings, cannot access www.thethingsnetwork.org"
-	echo "Check network settings and rerun this script to correct the setup"
+	echo "Error in network settings: cannot access www.thethingsnetwork.org."
+	echo "Check network settings and rerun this script to correct the setup."
 	grep -v network $STATUSFILE > $STATUSFILE.tmp
 	mv $STATUSFILE.tmp $STATUSFILE
 	exit 1

--- a/installer.sh
+++ b/installer.sh
@@ -24,8 +24,7 @@ grep secure $STATUSFILE > /dev/null 2> /dev/null
 if [ $? -ne 0 ] ; then
 	# Start by securing the device
 	echo "We start by securing access to the Conduit, which initially is open."
-	echo "When prompted, enter the old password for root access (initially 'root')"
-	echo "and then enter a new password to be used to control root access."
+	echo "When prompted, enter the password to be used to control root access."
 	echo "Please be sure to save this password, as the Conduit requires factory"
 	echo "reset when the password is lost!!"
 	echo ""

--- a/installer.sh
+++ b/installer.sh
@@ -14,7 +14,7 @@ FILENAME=poly-packet-forwarder_${VERSION}_arm926ejste.ipk
 URL=https://raw.github.com/kersing/multitech-installer/master/${FILENAME}
 
 if [ ! -f $STATUSFILE ] ; then
-	touch /var/config/.installer
+	touch $STATUSFILE
 fi
 
 grep secure $STATUSFILE > /dev/null 2> /dev/null

--- a/installer.sh
+++ b/installer.sh
@@ -719,6 +719,7 @@ if [ $? -ne 0 ] ; then
 _EOF_
 	if [ X"$lat" != X"0" -o X"$lon" != X"0" ] ; then
 		echo '        "fake_gps": true,' >> /var/config/lora/local_conf.json
+		echo '        "gps" : true,' >> /var/config/lora/local_conf.json
 	else
 		echo '        "fake_gps": false,' >> /var/config/lora/local_conf.json
 	fi

--- a/installer.sh
+++ b/installer.sh
@@ -13,6 +13,9 @@ FILENAME=poly-packet-forwarder_${VERSION}_arm926ejste.ipk
 #URL=https://raw.github.com/kersing/packet_forwarder/master/multitech-bin/${FILENAME}
 URL=https://raw.github.com/kersing/multitech-installer/master/${FILENAME}
 
+#
+# always start with an empty status file.
+#
 if [ ! -f $STATUSFILE ] ; then
 	touch $STATUSFILE
 fi

--- a/installer.sh
+++ b/installer.sh
@@ -37,6 +37,7 @@ if [ $? -ne 0 ] ; then
 		echo "secure" >> $STATUSFILE
 	else
 		echo "Password not set, exiting. Please restart the install process."
+		exit 1
 	fi
 fi
 


### PR DESCRIPTION
A minor roll-up of changes. Feel free to separate into separate upstream pushes.
1. Improve documentation and prompting.
2. Exit with non-zero status if `passwd' returns non-zero exit status, rather than setting the "password-set" flag and continuing.
3. Add "gps": true to local_conf.json if GPS is enabled, so that the gateway will show up in the upstream databases with location information.
